### PR TITLE
HIVE-25721: Outer join result is wrong

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,7 +272,7 @@ time docker rm -f dev_$dbType || true
           stage('verify') {
             try {
               sh """#!/bin/bash -e
-mvn verify -DskipITests=false -Dit.test=ITest${dbType.capitalize()} -Dtest=nosuch -pl standalone-metastore/metastore-server -Dmaven.test.failure.ignore -B -Ditest.jdbc.jars=`find /apps/lib/ -type f | paste -s -d:`
+mvn verify -DskipITests=false -Dit.test=ITest${dbType.capitalize()} -Dtest=nosuch -pl standalone-metastore/metastore-server -Dmaven.test.failure.ignore -B
 """
             } finally {
               junit '**/TEST-*.xml'

--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -193,8 +193,6 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${postgres.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3467,6 +3467,9 @@ public class HiveConf extends Configuration {
         "hive.test.authz.sstd.hs2.mode", false, "test hs2 mode from .q tests", true),
     HIVE_AUTHORIZATION_ENABLED("hive.security.authorization.enabled", false,
         "enable or disable the Hive client authorization"),
+    HIVE_AUTHORIZATION_ENABLED_ON_SPARK_VIEWS("hive.security.authorization.enabled.on.spark.views",true,
+            "The configuration is gives the flexibility to admin to user whether to turn on/off the authorization model" +
+                    "introduced in HIVE-24026"),
     HIVE_AUTHORIZATION_KERBEROS_USE_SHORTNAME("hive.security.authorization.kerberos.use.shortname", true,
         "use short name in Kerberos cluster"),
     HIVE_AUTHORIZATION_MANAGER("hive.security.authorization.manager",

--- a/contrib/src/test/queries/clientpositive/url_hook.q
+++ b/contrib/src/test/queries/clientpositive/url_hook.q
@@ -1,3 +1,4 @@
+--! qt:disabled:HIVE-25712
 --! qt:dataset:src
 add jar ${system:maven.local.repository}/org/apache/hive/hive-contrib/${system:hive.version}/hive-contrib-${system:hive.version}.jar;
 SHOW TABLES 'src';

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
@@ -178,28 +179,61 @@ public final class HiveSchemaUtil {
   }
 
   /**
-   * Compares a list of columns to another list, by name, to find an out of order column.
-   * It iterates through updated one by one, and compares the name of the column to the name of the column in the old
-   * list, in the same position. It returns the first mismatch it finds in updated, if any.
+   * Compares two lists of columns to each other to find the (singular) column that was moved. This works ideally for
+   * identifying the column that was moved by an ALTER TABLE ... CHANGE COLUMN command.
    *
-   * @param updated The list of the columns after some updates have taken place
+   * Note: This method is only suitable for finding a single reordered column.
+   * Consequently, this method is NOT suitable for handling scenarios where multiple column reorders are possible at the
+   * same time, such as ALTER TABLE ... REPLACE COLUMNS commands.
+   *
+   * @param updated The list of the columns after some updates have taken place (if any)
    * @param old The list of the original columns
    * @param renameMapping A map of name aliases for the updated columns (e.g. if a column rename occurred)
-   * @return A pair consisting of the first out of order column name, and its preceding column name (if any).
+   * @return A pair consisting of the reordered column's name, and its preceding column's name (if any).
    *         Returns a null in case there are no out of order columns.
    */
-  public static Pair<String, Optional<String>> getFirstOutOfOrderColumn(List<FieldSchema> updated,
+  public static Pair<String, Optional<String>> getReorderedColumn(List<FieldSchema> updated,
                                                                         List<FieldSchema> old,
                                                                         Map<String, String> renameMapping) {
-    for (int i = 0; i < updated.size() && i < old.size(); ++i) {
+    // first collect the updated index for each column
+    Map<String, Integer> nameToNewIndex = Maps.newHashMap();
+    for (int i = 0; i < updated.size(); ++i) {
       String updatedCol = renameMapping.getOrDefault(updated.get(i).getName(), updated.get(i).getName());
-      String oldCol = old.get(i).getName();
-      if (!oldCol.equals(updatedCol)) {
-        Optional<String> previousCol = i > 0 ? Optional.of(updated.get(i - 1).getName()) : Optional.empty();
-        return Pair.of(updatedCol, previousCol);
+      nameToNewIndex.put(updatedCol, i);
+    }
+
+    // find the column which has the highest index difference between its position in the old vs the updated list
+    String reorderedColName = null;
+    int maxIndexDiff = 0;
+    for (int oldIndex = 0; oldIndex < old.size(); ++oldIndex) {
+      String oldName = old.get(oldIndex).getName();
+      Integer newIndex = nameToNewIndex.get(oldName);
+      if (newIndex != null) {
+        int indexDiff = Math.abs(newIndex - oldIndex);
+        if (maxIndexDiff < indexDiff) {
+          maxIndexDiff = indexDiff;
+          reorderedColName = oldName;
+        }
       }
     }
-    return null;
+
+    if (maxIndexDiff == 0) {
+      // if there are no changes in index, there were no reorders
+      return null;
+    } else {
+      int newIndex = nameToNewIndex.get(reorderedColName);
+      if (newIndex > 0) {
+        // if the newIndex > 0, that means the column was moved after another column:
+        // ALTER TABLE tbl CHANGE COLUMN reorderedColName reorderedColName type AFTER previousColName;
+        String previousColName = renameMapping.getOrDefault(
+            updated.get(newIndex - 1).getName(), updated.get(newIndex - 1).getName());
+        return Pair.of(reorderedColName, Optional.of(previousColName));
+      } else {
+        // if the newIndex is 0, that means the column was moved to the first position:
+        // ALTER TABLE tbl CHANGE COLUMN reorderedColName reorderedColName type FIRST;
+        return Pair.of(reorderedColName, Optional.empty());
+      }
+    }
   }
 
   public static class SchemaDifference {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -574,7 +574,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       schemaDifference.getMissingFromFirst().forEach(icebergCols::remove);
     }
 
-    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getFirstOutOfOrderColumn(
+    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getReorderedColumn(
         hmsCols, icebergCols, ImmutableMap.of());
 
     // limit the scope of this operation to only dropping columns
@@ -612,8 +612,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
           schemaDifference.getMissingFromSecond().get(0).getName(),
           schemaDifference.getMissingFromFirst().get(0).getName());
     }
-    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getFirstOutOfOrderColumn(hmsCols, icebergCols,
-        renameMapping);
+    Pair<String, Optional<String>> outOfOrder = HiveSchemaUtil.getReorderedColumn(hmsCols, icebergCols, renameMapping);
 
     if (!schemaDifference.isEmpty() || outOfOrder != null) {
       transaction = icebergTable.newTransaction();

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSchemaEvolution.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSchemaEvolution.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.Assert;
@@ -90,6 +91,53 @@ public class TestHiveIcebergSchemaEvolution extends HiveIcebergStorageHandlerWit
     Assert.assertArrayEquals(new Object[]{1L, "Green"}, result.get(1));
     Assert.assertArrayEquals(new Object[]{2L, "Pink"}, result.get(2));
 
+  }
+
+  @Test
+  public void testColumnReorders() throws IOException {
+    Schema schema = new Schema(
+        required(1, "a", Types.LongType.get()),
+        required(2, "b", Types.StringType.get()),
+        required(3, "c", Types.StringType.get()),
+        required(4, "d", Types.IntegerType.get()),
+        required(5, "e", Types.IntegerType.get()),
+        required(6, "f", Types.StringType.get())
+    );
+    testTables.createTable(shell, "customers", schema, fileFormat, ImmutableList.of());
+    shell.executeStatement("INSERT INTO customers VALUES (1, 'foo', 'bar', 33, 44, 'baz'), " +
+        "(2, 'foo2', 'bar2', 55, 66, 'baz2')");
+
+    // move one position to the right
+    // a,b,c,d,e,f -> b,a,c,d,e,f
+    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN a a bigint AFTER b");
+    List<Object[]> result = shell.executeStatement("SELECT * FROM customers ORDER BY a");
+    Assert.assertEquals(2, result.size());
+    Assert.assertArrayEquals(new Object[]{"foo", 1L, "bar", 33, 44, "baz"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{"foo2", 2L, "bar2", 55, 66, "baz2"}, result.get(1));
+
+    // move first to the last
+    // b,a,c,d,e,f -> a,c,d,e,f,b
+    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN b b string AFTER f");
+    result = shell.executeStatement("SELECT * FROM customers ORDER BY a");
+    Assert.assertEquals(2, result.size());
+    Assert.assertArrayEquals(new Object[]{1L, "bar", 33, 44, "baz", "foo"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{2L, "bar2", 55, 66, "baz2", "foo2"}, result.get(1));
+
+    // move middle to the first
+    // a,c,d,e,f,b -> e,a,c,d,f,b
+    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN e e int FIRST");
+    result = shell.executeStatement("SELECT * FROM customers ORDER BY a");
+    Assert.assertEquals(2, result.size());
+    Assert.assertArrayEquals(new Object[]{44, 1L, "bar", 33, "baz", "foo"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{66, 2L, "bar2", 55, "baz2", "foo2"}, result.get(1));
+
+    // move one position to the left
+    // e,a,c,d,f,b -> e,a,d,c,f,b
+    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN d d int AFTER a");
+    result = shell.executeStatement("SELECT * FROM customers ORDER BY a");
+    Assert.assertEquals(2, result.size());
+    Assert.assertArrayEquals(new Object[]{44, 1L, 33, "bar", "baz", "foo"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{66, 2L, 55, "bar2", "baz2", "foo2"}, result.get(1));
   }
 
   // Tests CHANGE COLUMN feature similarly like above, but with a more complex schema, aimed to verify vectorized

--- a/iceberg/iceberg-handler/src/test/queries/positive/llap_iceberg_read.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/llap_iceberg_read.q
@@ -53,8 +53,8 @@ SELECT i.name, i.description, SUM(o.quantity) FROM llap_items i JOIN llap_orders
 --adding a column
 ALTER TABLE llap_items ADD COLUMNS (to60 float);
 INSERT INTO llap_items VALUES
-(7, 'Model X', 93000, 'SUV', 'Long range', 3.8),
-(7, 'Model X', 113000, 'SUV', 'Plaid', 2.5);
+(7, 'Model X', 93000, 'Long range', 'SUV', 3.8),
+(7, 'Model X', 113000, 'Plaid', 'SUV', 2.5);
 SELECT cat, min(to60) from llap_items group by cat;
 
 --removing a column
@@ -70,7 +70,7 @@ SELECT name, min(to60), max(cost) FROM llap_items WHERE itemid > 3 GROUP BY name
 ALTER TABLE llap_orders CHANGE tradets ordertime timestamp AFTER p2;
 ALTER TABLE llap_orders CHANGE p1 region string;
 INSERT INTO llap_orders VALUES
-(21, 21, 8, 'EU', timestamp('2000-01-04 19:55:46.129'), 'HU');
+(21, 21, 8, 'EU', 'HU', timestamp('2000-01-04 19:55:46.129'));
 SELECT region, min(ordertime), sum(quantity) FROM llap_orders WHERE itemid > 5 GROUP BY region;
 
 ALTER TABLE llap_orders CHANGE p2 state string;
@@ -79,25 +79,25 @@ SELECT region, state, min(ordertime), sum(quantity) FROM llap_orders WHERE itemi
 --adding new column
 ALTER TABLE llap_orders ADD COLUMNS (city string);
 INSERT INTO llap_orders VALUES
-(22, 99, 9, 'EU', timestamp('2021-01-04 19:55:46.129'), 'DE', 'München');
+(22, 99, 9, 'EU', 'DE', timestamp('2021-01-04 19:55:46.129'), 'München');
 SELECT state, max(city) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 --making it a partition column
 ALTER TABLE llap_orders SET PARTITION SPEC (region, state, city);
 INSERT INTO llap_orders VALUES
-(23, 89, 6, 'EU', timestamp('2021-02-04 19:55:46.129'), 'IT', 'Venezia');
+(23, 89, 6, 'EU', 'IT', timestamp('2021-02-04 19:55:46.129'), 'Venezia');
 SELECT state, max(city), avg(itemid) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 --de-partitioning a column
 ALTER TABLE llap_orders SET PARTITION SPEC (state, city);
 INSERT INTO llap_orders VALUES
-(24, 88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'UK', 'London');
+(24, 88, 5, 'EU', 'UK', timestamp('2006-02-04 19:55:46.129'), 'London');
 SELECT state, max(city), avg(itemid) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 --removing a column from schema
-ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', state string COMMENT 'from deserializer', city string);
+ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', state string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', city string);
 INSERT INTO llap_orders VALUES
-(88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'FR', 'Paris');
+(88, 5, 'EU', 'FR', timestamp('2006-02-04 19:55:46.129'), 'Paris');
 SELECT state, max(city), avg(itemid) from llap_orders WHERE region = 'EU' GROUP BY state;
 
 

--- a/iceberg/iceberg-handler/src/test/queries/positive/vectorized_iceberg_read.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/vectorized_iceberg_read.q
@@ -42,7 +42,7 @@ insert into tbl_ice_orc_parted values
 -- query with projection of partition columns' subset
 select p1, a, min(b) from tbl_ice_orc_parted group by p1, a;
 
--- required for reordering between differnt types
+-- required for reordering between different types
 set hive.metastore.disallow.incompatible.col.type.changes=false;
 
 -- move partition columns
@@ -59,7 +59,7 @@ describe tbl_ice_orc_parted;
 -- should yield to the same result as previously
 select p1, a, min(b) from tbl_ice_orc_parted group by p1, a;
 
-insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria');
+insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria');
 
 -- projecting all columns
 select p1, p2, a, min(b) from tbl_ice_orc_parted group by p1, p2, a;

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/llap_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/llap_iceberg_read.q.out
@@ -144,14 +144,14 @@ POSTHOOK: type: ALTERTABLE_ADDCOLS
 POSTHOOK: Input: default@llap_items
 POSTHOOK: Output: default@llap_items
 PREHOOK: query: INSERT INTO llap_items VALUES
-(7, 'Model X', 93000, 'SUV', 'Long range', 3.8),
-(7, 'Model X', 113000, 'SUV', 'Plaid', 2.5)
+(7, 'Model X', 93000, 'Long range', 'SUV', 3.8),
+(7, 'Model X', 113000, 'Plaid', 'SUV', 2.5)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_items
 POSTHOOK: query: INSERT INTO llap_items VALUES
-(7, 'Model X', 93000, 'SUV', 'Long range', 3.8),
-(7, 'Model X', 113000, 'SUV', 'Plaid', 2.5)
+(7, 'Model X', 93000, 'Long range', 'SUV', 3.8),
+(7, 'Model X', 113000, 'Plaid', 'SUV', 2.5)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_items
@@ -216,12 +216,12 @@ POSTHOOK: type: ALTERTABLE_RENAMECOL
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(21, 21, 8, 'EU', timestamp('2000-01-04 19:55:46.129'), 'HU')
+(21, 21, 8, 'EU', 'HU', timestamp('2000-01-04 19:55:46.129'))
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(21, 21, 8, 'EU', timestamp('2000-01-04 19:55:46.129'), 'HU')
+(21, 21, 8, 'EU', 'HU', timestamp('2000-01-04 19:55:46.129'))
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -264,12 +264,12 @@ POSTHOOK: type: ALTERTABLE_ADDCOLS
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(22, 99, 9, 'EU', timestamp('2021-01-04 19:55:46.129'), 'DE', 'München')
+(22, 99, 9, 'EU', 'DE', timestamp('2021-01-04 19:55:46.129'), 'München')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(22, 99, 9, 'EU', timestamp('2021-01-04 19:55:46.129'), 'DE', 'München')
+(22, 99, 9, 'EU', 'DE', timestamp('2021-01-04 19:55:46.129'), 'München')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -295,12 +295,12 @@ POSTHOOK: type: ALTERTABLE_SETPARTSPEC
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(23, 89, 6, 'EU', timestamp('2021-02-04 19:55:46.129'), 'IT', 'Venezia')
+(23, 89, 6, 'EU', 'IT', timestamp('2021-02-04 19:55:46.129'), 'Venezia')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(23, 89, 6, 'EU', timestamp('2021-02-04 19:55:46.129'), 'IT', 'Venezia')
+(23, 89, 6, 'EU', 'IT', timestamp('2021-02-04 19:55:46.129'), 'Venezia')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -326,12 +326,12 @@ POSTHOOK: type: ALTERTABLE_SETPARTSPEC
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(24, 88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'UK', 'London')
+(24, 88, 5, 'EU', 'UK', timestamp('2006-02-04 19:55:46.129'), 'London')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(24, 88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'UK', 'London')
+(24, 88, 5, 'EU', 'UK', timestamp('2006-02-04 19:55:46.129'), 'London')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders
@@ -349,21 +349,21 @@ FR	NULL	2.75
 HU	NULL	7.0
 IT	Venezia	6.0
 UK	London	2.0
-PREHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', state string COMMENT 'from deserializer', city string)
+PREHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', state string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', city string)
 PREHOOK: type: ALTERTABLE_REPLACECOLS
 PREHOOK: Input: default@llap_orders
 PREHOOK: Output: default@llap_orders
-POSTHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', state string COMMENT 'from deserializer', city string)
+POSTHOOK: query: ALTER TABLE llap_orders REPLACE COLUMNS (quantity int, itemid int, region string COMMENT 'from deserializer', state string COMMENT 'from deserializer', ordertime timestamp COMMENT 'from deserializer', city string)
 POSTHOOK: type: ALTERTABLE_REPLACECOLS
 POSTHOOK: Input: default@llap_orders
 POSTHOOK: Output: default@llap_orders
 PREHOOK: query: INSERT INTO llap_orders VALUES
-(88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'FR', 'Paris')
+(88, 5, 'EU', 'FR', timestamp('2006-02-04 19:55:46.129'), 'Paris')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@llap_orders
 POSTHOOK: query: INSERT INTO llap_orders VALUES
-(88, 5, 'EU', timestamp('2006-02-04 19:55:46.129'), 'FR', 'Paris')
+(88, 5, 'EU', 'FR', timestamp('2006-02-04 19:55:46.129'), 'Paris')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@llap_orders

--- a/iceberg/iceberg-handler/src/test/results/positive/llap/vectorized_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/llap/vectorized_iceberg_read.q.out
@@ -301,8 +301,8 @@ POSTHOOK: query: describe tbl_ice_orc_parted
 POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@tbl_ice_orc_parted
 p1                  	string              	from deserializer   
-a                   	int                 	from deserializer   
 b                   	string              	from deserializer   
+a                   	int                 	from deserializer   
 p2                  	string              	from deserializer   
 	 	 
 # Partition Transform Information	 	 
@@ -319,11 +319,11 @@ POSTHOOK: Input: default@tbl_ice_orc_parted
 #### A masked pattern was here ####
 America	2	aa
 Europe	1	aa
-PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tbl_ice_orc_parted
-POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice_orc_parted

--- a/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_read.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/vectorized_iceberg_read.q.out
@@ -229,8 +229,8 @@ POSTHOOK: query: describe tbl_ice_orc_parted
 POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@tbl_ice_orc_parted
 p1                  	string              	from deserializer   
-a                   	int                 	from deserializer   
 b                   	string              	from deserializer   
+a                   	int                 	from deserializer   
 p2                  	string              	from deserializer   
 	 	 
 # Partition Transform Information	 	 
@@ -247,11 +247,11 @@ POSTHOOK: Input: default@tbl_ice_orc_parted
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 America	2	aa
 Europe	1	aa
-PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+PREHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tbl_ice_orc_parted
-POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 3, 'cc', 'Austria')
+POSTHOOK: query: insert into tbl_ice_orc_parted values ('Europe', 'cc', 3, 'Austria')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tbl_ice_orc_parted

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestScheduledReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestScheduledReplicationScenarios.java
@@ -254,6 +254,7 @@ public class TestScheduledReplicationScenarios extends BaseReplicationScenariosA
   }
 
   @Test
+  @Ignore("HIVE-25720")
   public void testCompleteFailoverWithReverseBootstrap() throws Throwable {
     String withClause = "'" + HiveConf.ConfVars.HIVE_IN_TEST + "' = 'true','"
             + HiveConf.ConfVars.REPL_RETAIN_PREV_DUMP_DIR + "'='true'" ;
@@ -400,6 +401,7 @@ public class TestScheduledReplicationScenarios extends BaseReplicationScenariosA
   }
 
   @Test
+  @Ignore("HIVE-25720")
   public void testSetPolicyId() throws Throwable {
     String withClause =
         " WITH('" + HiveConf.ConfVars.HIVE_IN_TEST + "' = 'true'" + ",'"

--- a/itests/qtest-iceberg/pom.xml
+++ b/itests/qtest-iceberg/pom.xml
@@ -382,18 +382,12 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <!-- Note, this is LGPL.  But we're only using it in a test and not changing it, so I
-            believe we are fine. -->
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>${mariadb.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgres.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -446,7 +440,6 @@
                     <additionalClasspathElements>
                         <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>
                         <additionalClasspathElement>${basedir}/${hive.path.to.root}/conf</additionalClasspathElement>
-                        <additionalClasspathElement>${itest.jdbc.jars}</additionalClasspathElement>
                     </additionalClasspathElements>
                 </configuration>
             </plugin>

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -404,31 +404,26 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <!-- JDBC drivers -->
     <dependency>
-      <!-- Note, this is LGPL.  But we're only using it in a test and not changing it, so I
-      believe we are fine. -->
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>${mariadb.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${postgres.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>${mysql.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc8</artifactId>
-      <version>${oracle.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <profiles>
@@ -489,23 +484,6 @@
   </profiles>
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.googlecode.maven-download-plugin</groupId>
-        <artifactId>download-maven-plugin</artifactId>
-        <version>1.3.0</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <url>http://downloads.mariadb.com/Connectors/java/connector-java-2.2.0/mariadb-java-client-2.2.0.jar</url>
-              <outputFileName>mariadb-java-client-2.2.0.jar</outputFileName>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
@@ -604,8 +582,6 @@
           <additionalClasspathElements>
             <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>
             <additionalClasspathElement>${basedir}/${hive.path.to.root}/conf</additionalClasspathElement>
-            <additionalClasspathElement>${itest.jdbc.jars}</additionalClasspathElement>
-            <additionalClasspathElement>${project.build.directory}/mariadb-java-client-2.2.0.jar</additionalClasspathElement>
           </additionalClasspathElements>
         </configuration>
       </plugin>

--- a/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/TestLlapTaskSchedulerService.java
+++ b/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/TestLlapTaskSchedulerService.java
@@ -603,6 +603,7 @@ public class TestLlapTaskSchedulerService {
 
 
   @Test(timeout = 10000)
+  @org.junit.Ignore("HIVE-25713")
   public void testPreemption() throws InterruptedException, IOException {
 
     Priority priority1 = Priority.newInstance(1);

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,6 @@
 
     <!-- Test Properties -->
     <test.extra.path></test.extra.path>
-    <itest.jdbc.jars>set-this-to-colon-separated-full-path-list-of-jars-to-run-integration-tests
-    </itest.jdbc.jars>
     <!--suppress UnresolvedMavenProperty -->
     <test.hive.hadoop.classpath>${maven.test.classpath}</test.hive.hadoop.classpath>
     <test.log4j.scheme>file://</test.log4j.scheme>
@@ -182,6 +180,7 @@
     <libthrift.version>0.14.1</libthrift.version>
     <log4j2.version>2.13.2</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
+    <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.27</mysql.version>
     <postgres.version>42.2.14</postgres.version>
     <oracle.version>21.3.0.0</oracle.version>
@@ -585,11 +584,6 @@
           </exclusion>
         </exclusions>
      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derby</artifactId>
-        <version>${derby.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
@@ -1274,6 +1268,49 @@
         <groupId>org.apache.tez</groupId>
         <artifactId>tez-common</artifactId>
         <version>${tez.version}</version>
+        </dependency>
+      <!-- JDBC drivers -->
+      <dependency>
+        <groupId>com.microsoft.sqlserver</groupId>
+        <artifactId>mssql-jdbc</artifactId>
+        <version>${mssql.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.database.jdbc</groupId>
+        <artifactId>ojdbc8</artifactId>
+        <version>${oracle.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>${mysql.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <version>${derby.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.mariadb.jdbc</groupId>
+        <artifactId>mariadb-java-client</artifactId>
+        <version>${mariadb.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${postgres.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -1564,7 +1601,6 @@
           <additionalClasspathElements>
             <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>
             <additionalClasspathElement>${basedir}/${hive.path.to.root}/conf</additionalClasspathElement>
-            <additionalClasspathElement>${itest.jdbc.jars}</additionalClasspathElement>
           </additionalClasspathElements>
           <environmentVariables>
             <TZ>US/Pacific</TZ>

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.translator.TypeConverter;
 import org.apache.hadoop.hive.ql.parse.CBOPlan;
 import org.apache.hadoop.hive.ql.parse.CalcitePlanner;
 import org.apache.hadoop.hive.ql.parse.ParseUtils;
+import org.apache.hadoop.hive.ql.parse.QueryTables;
 import org.apache.hadoop.hive.ql.parse.RowResolver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -459,7 +460,7 @@ public final class HiveMaterializedViewsRegistry {
       // for materialized views.
       RelOptHiveTable optTable = new RelOptHiveTable(null, cluster.getTypeFactory(), fullyQualifiedTabName,
           rowType, viewTable, nonPartitionColumns, partitionColumns, new ArrayList<>(),
-          conf, null, new HashMap<>(), new HashMap<>(), new HashMap<>(), new AtomicInteger());
+          conf, null, new QueryTables(true), new HashMap<>(), new HashMap<>(), new AtomicInteger());
       DruidTable druidTable = new DruidTable(new DruidSchema(address, address, false),
           dataSource, RelDataTypeImpl.proto(rowType), metrics, DruidTable.DEFAULT_TIMESTAMP_COLUMN,
           intervals, null, null);
@@ -474,7 +475,7 @@ public final class HiveMaterializedViewsRegistry {
       // for materialized views.
       RelOptHiveTable optTable = new RelOptHiveTable(null, cluster.getTypeFactory(), fullyQualifiedTabName,
           rowType, viewTable, nonPartitionColumns, partitionColumns, new ArrayList<>(),
-          conf, null, new HashMap<>(), new HashMap<>(), new HashMap<>(), new AtomicInteger());
+          conf, null, new QueryTables(true), new HashMap<>(), new HashMap<>(), new AtomicInteger());
       tableRel = new HiveTableScan(cluster, cluster.traitSetOf(HiveRelNode.CONVENTION), optTable,
           viewTable.getTableName(), null, false, false);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/RelOptHiveTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/RelOptHiveTable.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.ql.optimizer.calcite.translator.ExprNodeConverter;
 import org.apache.hadoop.hive.ql.optimizer.ppr.PartitionPruner;
 import org.apache.hadoop.hive.ql.parse.ColumnStatsList;
+import org.apache.hadoop.hive.ql.parse.ParsedQueryTables;
 import org.apache.hadoop.hive.ql.parse.PrunedPartitionList;
 import org.apache.hadoop.hive.ql.plan.ColStatistics;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
@@ -82,6 +83,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class RelOptHiveTable implements RelOptTable {
 
@@ -102,11 +104,12 @@ public class RelOptHiveTable implements RelOptTable {
   private final int                               noOfNonVirtualCols;
   private final List<ImmutableBitSet>             keys;
   private final List<ImmutableBitSet>             nonNullablekeys;
-  private final List<RelReferentialConstraint>    referentialConstraints;
+  private List<RelReferentialConstraint>          referentialConstraints;
+  private boolean                                 fetchedReferentialConstraints;
   private final HiveConf                          hiveConf;
 
   private final Hive                              db;
-  private final Map<String, Table>                tablesCache;
+  private final ParsedQueryTables                 tablesCache;
   private final Map<String, PrunedPartitionList>  partitionCache;
   private final Map<String, ColumnStatsList>      colStatsCache;
   private final AtomicInteger                     noColsMissingStats;
@@ -119,7 +122,7 @@ public class RelOptHiveTable implements RelOptTable {
 
   public RelOptHiveTable(RelOptSchema calciteSchema, RelDataTypeFactory typeFactory, List<String> qualifiedTblName,
       RelDataType rowType, Table hiveTblMetadata, List<ColumnInfo> hiveNonPartitionCols, List<ColumnInfo> hivePartitionCols,
-      List<VirtualColumn> hiveVirtualCols, HiveConf hconf, Hive db, Map<String, Table> tabNameToTabObject,
+      List<VirtualColumn> hiveVirtualCols, HiveConf hconf, Hive db, ParsedQueryTables tabNameToTabObject,
       Map<String, PrunedPartitionList> partitionCache, Map<String, ColumnStatsList> colStatsCache,
       AtomicInteger noColsMissingStats) {
     this.schema = calciteSchema;
@@ -144,7 +147,6 @@ public class RelOptHiveTable implements RelOptTable {
     Pair<List<ImmutableBitSet>, List<ImmutableBitSet>> constraintKeys = generateKeys();
     this.keys = constraintKeys.left;
     this.nonNullablekeys = constraintKeys.right;
-    this.referentialConstraints = generateReferentialConstraints();
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -248,6 +250,11 @@ public class RelOptHiveTable implements RelOptTable {
     return false;
   }
 
+  public boolean hasReferentialConstraints() {
+    ForeignKeyInfo foreignKeyInfo = hiveTblMetadata.getForeignKeyInfo();
+    return foreignKeyInfo != null && !foreignKeyInfo.getForeignKeys().isEmpty();
+  }
+
   @Override
   public List<ImmutableBitSet> getKeys() {
     return keys;
@@ -255,6 +262,12 @@ public class RelOptHiveTable implements RelOptTable {
 
   @Override
   public List<RelReferentialConstraint> getReferentialConstraints() {
+    // Do a lazy load here. We only want to fetch the constraint tables that
+    // are used in the query.
+    if (!fetchedReferentialConstraints) {
+      referentialConstraints = generateReferentialConstraints();
+      fetchedReferentialConstraints = true;
+    }
     return referentialConstraints;
   }
 
@@ -333,12 +346,11 @@ public class RelOptHiveTable implements RelOptTable {
           parentTableQualifiedName.add(parentTableName);
           qualifiedName = parentTableName;
         }
-        Table parentTab = getTable(qualifiedName);
+        Table parentTab = tablesCache.getParsedTable(qualifiedName);
         if (parentTab == null) {
-          LOG.error("Table for primary key not found: "
-              + "databaseName: " + parentDatabaseName + ", "
-              + "tableName: " + parentTableName);
-          return ImmutableList.of();
+          // Table doesn't exist in the cache, so we don't need to track
+          // these referential constraints.
+          continue;
         }
         ImmutableList.Builder<IntPair> keys = ImmutableList.builder();
         for (ForeignKeyCol fkCol : fkCols) {
@@ -359,7 +371,7 @@ public class RelOptHiveTable implements RelOptTable {
           if (fkPos == rowType.getFieldNames().size()
               || pkPos == parentTab.getAllCols().size()) {
             LOG.error("Column for foreign key definition " + fkCol + " not found");
-            return ImmutableList.of();
+            continue;
           }
           keys.add(IntPair.of(fkPos, pkPos));
         }
@@ -368,21 +380,6 @@ public class RelOptHiveTable implements RelOptTable {
       }
     }
     return builder.build();
-  }
-
-  private Table getTable(String tableName) {
-    if (!tablesCache.containsKey(tableName)) {
-      try {
-        Table table = db.getTable(tableName);
-        if (table != null) {
-          tablesCache.put(tableName, table);
-        }
-        return table;
-      } catch (HiveException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    return tablesCache.get(tableName);
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1648,6 +1648,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
       perfLogger.perfLogBegin(this.getClass().getName(), PerfLogger.OPTIMIZER);
       try {
         calcitePlan = genLogicalPlan(getQB(), true, null, null);
+        // freeze the names in the hash map for objects that are only interested
+        // in the parsed tables in the original query.
+        tabNameToTabObject.markParsingCompleted();
         // if it is to create view, we do not use table alias
         resultSchema = convertRowSchemaToResultSetSchema(relToHiveRR.get(calcitePlan),
             (forViewCreation || getQB().isMaterializedView()) ? false : HiveConf.getBoolVar(conf,
@@ -3075,7 +3078,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
                   || qb.getAliasInsideView().contains(tableAlias.toLowerCase()), tableScanTrait);
         }
 
-        if (!optTable.getReferentialConstraints().isEmpty()) {
+        if (optTable.hasReferentialConstraints()) {
           profilesCBO.add(ExtendedCBOProfile.REFERENTIAL_CONSTRAINTS);
         }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseContext.java
@@ -97,7 +97,7 @@ public class ParseContext {
   // reducer
   private Map<String, PrunedPartitionList> prunedPartitions;
   private Map<String, ReadEntity> viewAliasToInput;
-  private Map<String, Table> tabNameToTabObject;
+  private QueryTables tabNameToTabObject;
 
   /**
    * The lineage information.
@@ -192,7 +192,7 @@ public class ParseContext {
       Context ctx, Map<String, String> idToTableNameMap, int destTableId,
       UnionProcContext uCtx, List<AbstractMapJoinOperator<? extends MapJoinDesc>> listMapJoinOpsNoReducer,
       Map<String, PrunedPartitionList> prunedPartitions,
-      Map<String, Table> tabNameToTabObject,
+      QueryTables tabNameToTabObject,
       Map<TableScanOperator, SampleDesc> opToSamplePruner,
       GlobalLimitCtx globalLimitCtx,
       Map<String, SplitSample> nameToSplitSample,
@@ -636,7 +636,7 @@ public class ParseContext {
     this.needViewColumnAuthorization = needViewColumnAuthorization;
   }
 
-  public Map<String, Table> getTabNameToTabObject() {
+  public QueryTables getTabNameToTabObject() {
     return tabNameToTabObject;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParsedQueryTables.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParsedQueryTables.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.hadoop.hive.ql.metadata.Table;
+
+/**
+ * Interface to fetch hash map containing query tables.
+ **/
+
+public interface ParsedQueryTables {
+  public Table getParsedTable(String name);
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QueryTables.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QueryTables.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+/**
+ * Class to fetch hash map containing query tables.
+ * This object is used to hold all the tables used in the query. This object
+ * is meant to be mutable until the parsing is complete. Once that happens,
+ * 'setImmutable' should be called so that any caller using this object
+ * will be given an immutable set.  If a caller tries to fetch the table map
+ * while this object is being built, an exception will be thrown.
+ **/
+
+import org.apache.hadoop.hive.ql.metadata.Table;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class QueryTables implements ParsedQueryTables {
+  private final Map<String, Table> tableObjects = new HashMap<>();
+
+  private Map<String, Table> parsedTableObjects;
+
+  public QueryTables(boolean isEmptyMap) {
+    if (isEmptyMap) {
+      markParsingCompleted();
+    }
+  }
+
+  public QueryTables() {
+    this(false);
+  }
+
+  public boolean containsKey(String name) {
+    return tableObjects.containsKey(name);
+  }
+
+  public void put(String name, Table table) {
+    tableObjects.put(name, table);
+  }
+
+  public void markParsingCompleted() {
+    parsedTableObjects = ImmutableMap.copyOf(tableObjects);
+  }
+
+  public Table get(String name) {
+    return tableObjects.get(name);
+  }
+
+  public Table getParsedTable(String name) {
+    if (parsedTableObjects == null) {
+      throw new RuntimeException("Cannot call getParsedTable() until parsing is marked " +
+          "completed.");
+    }
+    return parsedTableObjects.get(name);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -433,7 +433,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private WriteEntity acidAnalyzeTable;
 
   // A mapping from a tableName to a table object in metastore.
-  Map<String, Table> tabNameToTabObject;
+  QueryTables tabNameToTabObject;
 
   // The tokens we should ignore when we are trying to do table masking.
   private static final Set<Integer> IGNORED_TOKENS = Sets.newHashSet(HiveParser.TOK_GROUPBY,
@@ -500,7 +500,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     viewAliasToInput = new HashMap<String, ReadEntity>();
     mergeIsDirect = true;
     noscan = false;
-    tabNameToTabObject = new HashMap<>();
+    tabNameToTabObject = new QueryTables();
     defaultJoinMerge = !HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_MERGE_NWAY_JOINS);
     disableJoinMerge = defaultJoinMerge;
     defaultNullOrder = NullOrdering.defaultNullOrder(conf);
@@ -2693,7 +2693,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       if (viewMask.isEnabled() && analyzeRewrite == null) {
         ParseResult parseResult = rewriteASTWithMaskAndFilter(viewMask, viewTree,
             ctx.getViewTokenRewriteStream(viewFullyQualifiedName),
-            ctx, db, tabNameToTabObject);
+            ctx, db);
         viewTree = parseResult.getTree();
       }
       SemanticDispatcher nodeOriginDispatcher = new SemanticDispatcher() {
@@ -12272,7 +12272,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   // For the replacement, we leverage the methods that are used for
   // unparseTranslator.
   private ParseResult rewriteASTWithMaskAndFilter(TableMask tableMask, ASTNode ast, TokenRewriteStream tokenRewriteStream,
-                                                Context ctx, Hive db, Map<String, Table> tabNameToTabObject)
+                                                Context ctx, Hive db)
       throws SemanticException {
     // 1. collect information about CTE if there is any.
     // The base table of CTE should be masked.
@@ -12561,7 +12561,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         (tableMask.isEnabled() && analyzeRewrite == null)) {
       // Here we rewrite the * and also the masking table
       ParseResult rewrittenResult = rewriteASTWithMaskAndFilter(tableMask, astForMasking, ctx.getTokenRewriteStream(),
-          ctx, db, tabNameToTabObject);
+          ctx, db);
       ASTNode rewrittenAST = rewrittenResult.getTree();
       if (astForMasking != rewrittenAST) {
         usesMasking = true;

--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/command/CommandAuthorizerV2.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.DataConnector;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -159,7 +160,8 @@ final class CommandAuthorizerV2 {
     }
     if(isView){
       Map<String, String> params = t.getParameters();
-      if (params != null && params.containsKey(authorizedKeyword)) {
+      if (HiveConf.getBoolVar(SessionState.get().getConf(), HiveConf.ConfVars.HIVE_AUTHORIZATION_ENABLED_ON_SPARK_VIEWS)
+              && params != null && params.containsKey(authorizedKeyword)) {
         String authorizedValue = params.get(authorizedKeyword);
         if ("false".equalsIgnoreCase(authorizedValue)) {
           return true;

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/ITestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/ITestDbTxnManager.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Test class to run DbTxnManager tests against different dbms types.
- * Example: mvn test -Dtest=ITestDbTxnManager -Dtest.metastore.db=postgres -Ditest.jdbc.jars=yourPathtoJdbcDriver
+ * Example: mvn test -Dtest=ITestDbTxnManager -Dtest.metastore.db=postgres
  */
 public class ITestDbTxnManager extends TestDbTxnManager2 {
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -178,6 +178,7 @@ public class TestCompactionMetrics  extends CompactorTest {
   }
 
   @Test
+  @org.junit.Ignore("HIVE-25716")
   public void testOldestReadyForCleaningAge() throws Exception {
     conf.setIntVar(HiveConf.ConfVars.COMPACTOR_MAX_NUM_DELTA, 1);
 

--- a/ql/src/test/queries/clientpositive/replication_metrics_ingest.q
+++ b/ql/src/test/queries/clientpositive/replication_metrics_ingest.q
@@ -1,3 +1,4 @@
+--! qt:disabled:HIVE-25719
 --! qt:authorizer
 --! qt:scheduledqueryservice
 --! qt:sysdb

--- a/standalone-metastore/DEV-README
+++ b/standalone-metastore/DEV-README
@@ -23,25 +23,22 @@ quick test can be done for the unit tests and more in depth testing as part
 of the checkin tests.
 
 --------------------------------------------------------------------------------
-Testing metastore installation and upgrade against databases beyond Derby:
 There are integration tests for testing installation and upgrade of the
-metastore on MySQL (actually MariaDB is used), Oracle, Postgres, and SQLServer.
-These tests are not run by default because they take several minutes each and
-they require the developer to download the JDBC driver for Oracle.
-They are run in the integration-test phase.
+metastore on Derby, MySQL (actually MariaDB is used), Oracle, Postgres, and SQLServer.
 
 Each ITest runs two tests, one that installs the latest version of the
 database and one that installs the latest version minus one and then upgrades
 the database.
 
-To run one of the tests you will need to explicitly turn on integration testing,
-in the Oracle case specify the location of the JDBC driver, and optionally
-specify which test you want to run.  You'll need to download and start docker.
-Make sure docker's memory is set to more than 3.5GB.  To run all of the tests do:
+To run the tests you will need to explicitly turn on integration testing by
+setting skipITests variable to false. The tests rely on Docker so the latter
+needs to be installed and configured properly (e.g., memory more than 3.5GB).
 
-mvn verify -Ditest.jdbc.jars=_connector_jar_path -DskipITests=false -Dtest=nosuch
+Run all tests:
 
-To run just one test, do
+mvn verify -DskipITests=false -Dtest=nosuch
+
+Run a single test:
 
 mvn verify -DskipITests=false -Dit.test=ITestMysql -Dtest=nosuch
 
@@ -53,11 +50,6 @@ Supported databases for testing:
 -Dit.test=ITestMssql
 
 By adding -Dverbose.schematool the Schema Tool output becomes more detailed.
-
-Regarding connector jars:
- - You can download the Oracle driver at
-   http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html
-   You should download Oracle 11g Release 1, ojdbc6.jar
 
 Logs for tests are located under standalone-metastore/metastore-common/target/failsafe-reports
 

--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -554,7 +554,6 @@
           </systemPropertyVariables>
           <additionalClasspathElements>
             <additionalClasspathElement>${log4j.conf.dir}</additionalClasspathElement>
-            <additionalClasspathElement>${itest.jdbc.jars}</additionalClasspathElement>
           </additionalClasspathElements>
           <skipITs>${skipITests}</skipITs> <!-- set this to false to run these tests -->
         </configuration>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -262,11 +262,19 @@
       <groupId>com.cronutils</groupId>
       <artifactId>cron-utils</artifactId>
     </dependency>
+    <!-- JDBC drivers -->
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+    </dependency>
     <!-- test scope dependencies -->
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -300,7 +308,6 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -453,23 +460,6 @@
     <plugins>
       <!-- plugins are always listed in sorted order by groupId, artifactId -->
       <plugin>
-        <groupId>com.googlecode.maven-download-plugin</groupId>
-        <artifactId>download-maven-plugin</artifactId>
-        <version>1.3.0</version>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <url>http://downloads.mariadb.com/Connectors/java/connector-java-2.2.0/mariadb-java-client-2.2.0.jar</url>
-              <outputFileName>mariadb-java-client-2.2.0.jar</outputFileName>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
@@ -612,8 +602,6 @@
           </systemPropertyVariables>
           <additionalClasspathElements>
             <additionalClasspathElement>${log4j.conf.dir}</additionalClasspathElement>
-            <additionalClasspathElement>${itest.jdbc.jars}</additionalClasspathElement>
-            <additionalClasspathElement>${project.build.directory}/mariadb-java-client-2.2.0.jar</additionalClasspathElement>
           </additionalClasspathElements>
           <skipITs>${skipITests}</skipITs> <!-- set this to false to run these tests -->
         </configuration>

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ExceptionHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ExceptionHandler.java
@@ -44,8 +44,7 @@ public final class ExceptionHandler {
   /**
    * Throws if the input exception is the instance of the input class
    */
-  public <T extends Exception> ExceptionHandler
-      throwIfInstance(Class<T> t) throws T {
+  public <T extends Exception> ExceptionHandler throwIfInstance(Class<T> t) throws T {
     if (t.isInstance(e)) {
       throw t.cast(e);
     }
@@ -55,13 +54,29 @@ public final class ExceptionHandler {
   /**
    * Throws if the input exception is the instance of the one in the input classes
    */
-  public <T extends Exception> ExceptionHandler
-      throwIfInstance(Class ...te) throws T {
-    if (te != null) {
-      for (Class<T> t : te) {
-        throwIfInstance(t);
-      }
-    }
+  public <T1 extends Exception,
+          T2 extends Exception>
+  ExceptionHandler throwIfInstance(
+      Class<T1> te1,
+      Class<T2> te2) throws T1, T2 {
+    throwIfInstance(te1);
+    throwIfInstance(te2);
+    return this;
+  }
+
+  /**
+   * Throws if the input exception is the instance of the one in the input classes
+   */
+  public <T1 extends Exception,
+          T2 extends Exception,
+          T3 extends Exception>
+  ExceptionHandler throwIfInstance(
+      Class<T1> te1,
+      Class<T2> te2,
+      Class<T3> te3) throws T1, T2, T3 {
+    throwIfInstance(te1);
+    throwIfInstance(te2);
+    throwIfInstance(te3);
     return this;
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -3245,7 +3245,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   }
 
   private void drop_table_with_environment_context(final String dbname, final String name, final boolean deleteData,
-      final EnvironmentContext envContext, boolean dropPartitions) throws MetaException {
+      final EnvironmentContext envContext, boolean dropPartitions) throws MetaException, NoSuchObjectException {
     String[] parsedDbName = parseDbName(dbname, conf);
     startTableFunction("drop_table", parsedDbName[CAT_NAME], parsedDbName[DB_NAME], name);
 
@@ -5190,8 +5190,12 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
       PathAndDepth that = (PathAndDepth) o;
       return depth == that.depth && Objects.equals(path, that.path);
     }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestExceptionHandler.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestExceptionHandler.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.metastore;
 
 import java.io.IOException;
-
 import org.junit.Test;
 
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
@@ -120,5 +119,4 @@ public class TestExceptionHandler {
       assertTrue(e.getMessage().equals(ix.getMessage()));
     }
   }
-
 }

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -55,8 +55,6 @@
     <test.warehouse.scheme>file://</test.warehouse.scheme>
     <test.forkcount>1</test.forkcount>
     <skipITests>true</skipITests>
-    <itest.jdbc.jars>set-this-to-colon-separated-full-path-list-of-jars-to-run-integration-tests
-    </itest.jdbc.jars>
     <test.groups>org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest</test.groups>
 
     <!-- Plugin versions -->
@@ -75,7 +73,11 @@
     <datanucleus-jdo.version>3.2.0-release</datanucleus-jdo.version>
     <datanucleus-rdbms.version>5.2.4</datanucleus-rdbms.version>
     <derby.version>10.14.1.0</derby.version>
+    <mariadb.version>2.5.0</mariadb.version>
+    <mssql.version>6.2.1.jre8</mssql.version>
+    <mysql.version>8.0.27</mysql.version>
     <postgres.version>42.2.14</postgres.version>
+    <oracle.version>21.3.0.0</oracle.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
@@ -185,11 +187,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.derby</groupId>
-        <artifactId>derby</artifactId>
-        <version>${derby.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -331,15 +328,50 @@
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-
-      <!-- test scope dependencies -->
-
+      <!-- JDBC drivers -->
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>
-        <version>6.2.1.jre8</version>
-        <scope>test</scope>
+        <version>${mssql.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
       </dependency>
+      <dependency>
+        <groupId>com.oracle.database.jdbc</groupId>
+        <artifactId>ojdbc8</artifactId>
+        <version>${oracle.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>${mysql.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <version>${derby.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.mariadb.jdbc</groupId>
+        <artifactId>mariadb-java-client</artifactId>
+        <version>${mariadb.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${postgres.version}</version>
+        <scope>runtime</scope>
+        <optional>true</optional>
+      </dependency>
+      <!-- test scope dependencies -->
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
@@ -375,12 +407,6 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito-core.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${postgres.version}</version>
         <scope>test</scope>
       </dependency>
       <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->


### PR DESCRIPTION
For CommonMergeJoinOperator, the tableDesc will be null in the case that all columns in that table is not used. The tableDesc is null lead to using a dummy row to denote all rows in that table instead of adding row into rowContainer.
However, rows in that table cannot be ignored when it contains filter in on clause.

Reproduced steps are commented in the following ticket.